### PR TITLE
Dockerize the flask application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6.2
+LABEL maintainer="Arpit"
+
+COPY requirements.txt /opt/requirements.txt
+RUN pip install -r /opt/requirements.txt
+
+COPY . /opt/
+WORKDIR /opt/
+
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -68,4 +68,7 @@ api.add_resource(User, "/user/<string:user_name>", endpoint="User")
 
 
 if __name__ == "__main__":
-    app.run(debug=config["configuration"]["Debug_Option"])
+    app.run(
+        host='0.0.0.0',
+        debug=config["configuration"]["Debug_Option"]
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+flask-api:
+  build: .
+  volumes:
+    - .:/opt/
+  ports:
+    - 5000:5000


### PR DESCRIPTION
This fixes #2

- You'll need Docker and/or docker-compose. Get it [here](https://www.docker.com/get-docker).
  - Docker [install](https://docs.docker.com/engine/installation/)
  - docker-compose [install](https://docs.docker.com/compose/install/)

To build and run the image via docker only:
 - docker build -t flask-api .
 - docker run -p 5000:5000 --name flask-api -d flask-api

To build and run via docker-compose (youll need docker-compose):
 - docker-compose build
 - docker-compose up